### PR TITLE
config dupate

### DIFF
--- a/content/configuration/data-source-generic.md
+++ b/content/configuration/data-source-generic.md
@@ -56,7 +56,7 @@ The following parameters are available for configuring an MQTT data source:
 | Parameter                     | Required | Type      | Description |
 |-------------------------------|----------|-----------|-------------|
 | **HostNameOrIpAddress**       | Required | `string`  |  Host name or IP address of the MQTT server  <br><br>Allowed value: Any valid WS or TCP/IP endpoint address <br> Default value: `null`       |
-| **Port**                      | Optional | `integer` |  Port number of the MQTT  server. Required only if Protocol is TCP. <br><br>Allowed value: Valid port range or null <br> Default value: `null`  |
+| **Port**                      | Optional | `integer` |  Port number of the MQTT  server. Required only if **Protocol** is TCP. <br><br>Allowed value: Valid port range or null <br> Default value: `null`  |
 | **Protocol**                  | Optional | `enum`    |   The protocol used to communicate to the MQTT broker <br><br>Allowed value: `WS` or `TCP` <br> Default value: `TCP`         |
 | **TLS**                       | Optional | `enum`    |  Determines if TLS should be used and what version <br><br>Allowed value: `None`, `TLS`, `TLS11`, `TLS12`, `TLS13` <br> Default value: `TLS12`            |
 | **UserName**                  | Optional | `string`  | User name or client Id for accessing the MQTT server <br><br>Allowed value: any string <br> Default value: `null`  |

--- a/content/configuration/data-source-generic.md
+++ b/content/configuration/data-source-generic.md
@@ -56,7 +56,7 @@ The following parameters are available for configuring an MQTT data source:
 | Parameter                     | Required | Type      | Description |
 |-------------------------------|----------|-----------|-------------|
 | **HostNameOrIpAddress**       | Required | `string`  |  Host name or IP address of the MQTT server  <br><br>Allowed value: Any valid WS or TCP/IP endpoint address <br> Default value: `null`       |
-| **Port**                      | Required | `integer` |  Port number of the MQTT  server <br><br>Allowed value: Valid port range <br> Default value: `0`  |
+| **Port**                      | Optional | `integer` |  Port number of the MQTT  server. Required only if Protocol is TCP. <br><br>Allowed value: Valid port range or null <br> Default value: `null`  |
 | **Protocol**                  | Optional | `enum`    |   The protocol used to communicate to the MQTT broker <br><br>Allowed value: `WS` or `TCP` <br> Default value: `TCP`         |
 | **TLS**                       | Optional | `enum`    |  Determines if TLS should be used and what version <br><br>Allowed value: `None`, `TLS`, `TLS11`, `TLS12`, `TLS13` <br> Default value: `TLS12`            |
 | **UserName**                  | Optional | `string`  | User name or client Id for accessing the MQTT server <br><br>Allowed value: any string <br> Default value: `null`  |

--- a/content/configuration/data-source-sparkplug-b.md
+++ b/content/configuration/data-source-sparkplug-b.md
@@ -56,7 +56,7 @@ The following parameters are available for configuring an MQTT data source:
 | Parameter                     | Required | Type      | Description |
 |-------------------------------|----------|-----------|-------------|
 | **HostNameOrIpAddress**       | Required | `string`  |  Host name or IP address of the MQTT server  <br><br>Allowed value: Any valid WS or TCP/IP endpoint address |
-| **Port**                      | Required | `integer` |  Port number of the MQTT  server <br><br>Allowed value: Valid port range          |
+| **Port**                      | Optional | `integer` |  Port number of the MQTT  server. Required only if Protocol is TCP. <br><br>Allowed value: Valid port range or null <br> Default value: `null`  |
 | **PrimaryHostId** | Optional | `string` | The Id of the primary host. The adapter is considered the primary application. <br><br>Allowed value: Any string without the following characters: `+ # /`<br>Default value: `null`
 | **Protocol**                  | Optional | `enum`    |   The protocol used to communicate to the MQTT broker <br><br>Allowed value: `WS` or `TCP` <br> Default value: `TCP`         |
 | **TLS**                       | Optional | `enum`    |  Determines if TLS should be used and what version <br><br>Allowed value: None, `TLS`, `TLS11`, `TLS12`, `TLS13` <br> Default value: `TLS12`            |

--- a/content/configuration/data-source-sparkplug-b.md
+++ b/content/configuration/data-source-sparkplug-b.md
@@ -56,7 +56,7 @@ The following parameters are available for configuring an MQTT data source:
 | Parameter                     | Required | Type      | Description |
 |-------------------------------|----------|-----------|-------------|
 | **HostNameOrIpAddress**       | Required | `string`  |  Host name or IP address of the MQTT server  <br><br>Allowed value: Any valid WS or TCP/IP endpoint address |
-| **Port**                      | Optional | `integer` |  Port number of the MQTT  server. Required only if Protocol is TCP. <br><br>Allowed value: Valid port range or null <br> Default value: `null`  |
+| **Port**                      | Optional | `integer` |  Port number of the MQTT  server. Required only if **Protocol** is TCP. <br><br>Allowed value: Valid port range or null <br> Default value: `null`  |
 | **PrimaryHostId** | Optional | `string` | The Id of the primary host. The adapter is considered the primary application. <br><br>Allowed value: Any string without the following characters: `+ # /`<br>Default value: `null`
 | **Protocol**                  | Optional | `enum`    |   The protocol used to communicate to the MQTT broker <br><br>Allowed value: `WS` or `TCP` <br> Default value: `TCP`         |
 | **TLS**                       | Optional | `enum`    |  Determines if TLS should be used and what version <br><br>Allowed value: None, `TLS`, `TLS11`, `TLS12`, `TLS13` <br> Default value: `TLS12`            |


### PR DESCRIPTION
Hello. Update to port in our data source configuration. Port is only required when Protocol field is "TCP" and not required when it is "WS". It can also be set to null. 

I will make changes to jsonpath-syntax-for-value-retrieval.md in the near future so it is specific to mqtt