### PR TITLE
291230 configuration updates for MQTT adapter

### DIFF
--- a/content/configuration/data-selection-generic.md
+++ b/content/configuration/data-selection-generic.md
@@ -115,7 +115,7 @@ The following are examples of valid MQTT data selection configurations<sup>1</su
     "IndexField" : "$.Timestamp",
     "IndexFormat" : null,    
     "DataType" : "Geolocation",
-    "DataFields" : { "Latitude": "$.Float1", "Longitude": "S.Float2" }
+    "DataFields" : { "Latitude": "$.Float1", "Longitude": "$.Float2" }
   },
   {
     "Selected" : true,

--- a/content/toc.yml
+++ b/content/toc.yml
@@ -13,7 +13,7 @@
 - topicUid: MQTTConfiguration
   items: 
   - topicUid: ConfigurationTools
-  - topicUid: SystemComponentsConfiguration
+  - topicUid: PIAdapterForMQTTSystemComponentsConfiguration
     items: 
     - topicUid: SystemAndAdapterConfiguration
   - topicUid: PIAdapterForMQTTDataSourceConfiguration


### PR DESCRIPTION
Per feedback in 291230:

![image](https://user-images.githubusercontent.com/59098013/154423676-6d2ccd90-a8c8-4814-9444-7861fbdbc705.png)

Note that the missing actual values for MQTT System Components were due to the incorrectly referenced topic in the TOC. The TOC was updated with the correct reference to include the specific System Components topic for the MQTT adapter.