### PR TITLE
Update punctuation

### DIFF
--- a/content/configuration/data-source-generic.md
+++ b/content/configuration/data-source-generic.md
@@ -101,7 +101,7 @@ The following are examples of valid MQTT data source configurations:
     "Password": null,
     "ClientId" : "Test-Client-Id",
     "MQTTVersion" : "3.1.1",
-    "ValidateServerCertificate" : true
+    "ValidateServerCertificate" : true,
     "timeZone": "UTC",
     "streamIdPrefix": "MyPrefix.",
     "defaultStreamIdPattern": "{Topic}.{ValueField}"


### PR DESCRIPTION
In the Complete data source configuration section, added a comma after the default value ("true") for the ValidateServerCertificate parameter.